### PR TITLE
fix: Allow to edit gauges of an open event

### DIFF
--- a/src/Admin/Form/EventFormType.php
+++ b/src/Admin/Form/EventFormType.php
@@ -76,21 +76,18 @@ class EventFormType extends AbstractType
                 'row_attr' => [
                     'class' => 'form-floating mb-3',
                 ],
-                'disabled' => $event->isBookable(),
             ])
             ->add('childrenCapacity', IntegerType::class, [
                 'label' => 'Jauge enfants',
                 'row_attr' => [
                     'class' => 'form-floating mb-3',
                 ],
-                'disabled' => $event->isBookable(),
             ])
             ->add('bikesAvailable', IntegerType::class, [
                 'label' => 'Vélos de prêt',
                 'row_attr' => [
                     'class' => 'form-floating mb-3',
                 ],
-                'disabled' => $event->isBookable(),
             ])
             ->add('pahekoProjectId', IntegerType::class, [
                 'required' => false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed form field restrictions: adult capacity, children capacity, and bikes available fields in event management are now editable when events are marked as bookable, providing administrators greater flexibility when configuring event details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->