### PR TITLE
feat: allow phone number override per event

### DIFF
--- a/migrations/Version20260617085020.php
+++ b/migrations/Version20260617085020.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260617085020 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE event ADD phone_number VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE "event" DROP phone_number');
+    }
+}

--- a/src/Admin/Form/EventFormType.php
+++ b/src/Admin/Form/EventFormType.php
@@ -179,6 +179,17 @@ class EventFormType extends AbstractType
                 'help' => 'Généralement un Google doc pour permettre aux personnes qui ne viennent plus d\'échanger / de revendre leurs places. Si aucun fichier n\'est renseigné, l\'évènement pourra tout de même être publié mais la bourse aux échanges ne sera pas suggérée sur le site.',
                 'default_protocol' => null,
             ])
+            ->add('phoneNumber', TextType::class, [
+                'required' => false,
+                'label' => 'Numéro de téléphone',
+                'attr' => [
+                    'placeholder' => 'Numéro de téléphone',
+                ],
+                'row_attr' => [
+                    'class' => 'form-floating mb-3',
+                ],
+                'help' => 'Si renseigné, ce numéro remplacera le numéro habituel de l\'association dans le mail de rappel envoyé aux participant·es avant le départ.',
+            ])
         ;
     }
 

--- a/src/Email/EventReminderSender.php
+++ b/src/Email/EventReminderSender.php
@@ -17,12 +17,14 @@ class EventReminderSender
         private readonly MailerInterface $mailer,
         private readonly UrlGeneratorInterface $urlGenerator,
         #[Autowire(env: 'ASSOCIATION_PHONE_NUMBER')]
-        private readonly string $associationPhoneNumber,
+        private readonly string $defaultPhoneNumber,
     ) {
     }
 
     public function send(Registration $registration): void
     {
+        $event = $registration->getEvent();
+
         $email = new TemplatedEmail()
             ->from(new Address('contact@altercampagne.net', 'Altercampagne'))
             ->to(new Address($registration->getUser()->getEmail(), $registration->getUser()->getFullName()))
@@ -30,11 +32,11 @@ class EventReminderSender
             ->htmlTemplate('emails/event_reminder.html.twig')
             ->context([
                 'member_display_name' => $registration->getUser()->getPublicName(),
-                'event_name' => $registration->getEvent()->getName(),
+                'event_name' => $event->getName(),
                 'event_url' => $this->urlGenerator->generate('event_show', [
-                    'slug' => $registration->getEvent()->getSlug(),
+                    'slug' => $event->getSlug(),
                 ], UrlGeneratorInterface::ABSOLUTE_URL),
-                'association_phone_number' => $this->associationPhoneNumber,
+                'association_phone_number' => $event->getPhoneNumber() ?? $this->defaultPhoneNumber,
             ])
         ;
 

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -122,6 +122,9 @@ class Event
     #[ORM\Column(nullable: true)]
     private ?string $exchangeMarketLink = null;
 
+    #[ORM\Column(nullable: true)]
+    private ?string $phoneNumber = null;
+
     /**
      * @var Collection<int, Stage>
      */
@@ -499,6 +502,18 @@ class Event
     public function setExchangeMarketLink(?string $exchangeMarketLink): self
     {
         $this->exchangeMarketLink = $exchangeMarketLink;
+
+        return $this;
+    }
+
+    public function getPhoneNumber(): ?string
+    {
+        return $this->phoneNumber;
+    }
+
+    public function setPhoneNumber(?string $phoneNumber): self
+    {
+        $this->phoneNumber = $phoneNumber;
 
         return $this;
     }

--- a/templates/admin/event/edit.html.twig
+++ b/templates/admin/event/edit.html.twig
@@ -19,8 +19,14 @@
 
                         {{ form_row(form.name) }}
                         {{ form_row(form.description) }}
+                    </fieldset>
+
+                    <fieldset class="form-group border p-3 mt-3 bg-light">
+                        <legend class="w-auto px-2 pb-2"><i class="fa-solid fa-address-book me-2"></i> Informations pratiques</legend>
+
                         {{ form_row(form.openingDateForBookings) }}
                         {{ form_row(form.exchangeMarketLink) }}
+                        {{ form_row(form.phoneNumber) }}
                     </fieldset>
 
                     <fieldset class="form-group border p-3 mt-3 bg-light">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom phone numbers on individual events. When configured, event-specific phone numbers will be used in reminder emails sent to participants instead of the default association phone number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->